### PR TITLE
fix: Correct MostActiveMembers type and unify unique button IDs

### DIFF
--- a/src/layouts/index/landingpage.tsx
+++ b/src/layouts/index/landingpage.tsx
@@ -106,7 +106,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
 					</div>
 				</div>
 				<button
-					id="Button1"
+					id="LandingPage_NextButton"
 					disabled={load}
 					className="bg-[#4286f5] disabled:bg-transparent md:w-1/3 h-12 cursor-pointer disabled:cursor-not-allowed font-sans rounded w-full mt-2 md:mt-0"
 					onClick={handleSubmitProp}>

--- a/src/layouts/index/messagesimpact/messagesimpact.tsx
+++ b/src/layouts/index/messagesimpact/messagesimpact.tsx
@@ -146,7 +146,7 @@ const MessagesImpact: React.FC<MessagesImpactProps> = ({
           </div>
         )}
         <button
-          id="Button1"
+          id="messages-impact-next-btn"
           className="bg-[#4286f5] w-[95%] md:w-1/3 h-12 cursor-pointer items-start rounded"
           onClick={handleNext}
           style={{ visibility: isbuttonVisible ? "visible" : "hidden" }}

--- a/src/layouts/index/messagesperc/messagesperc.tsx
+++ b/src/layouts/index/messagesperc/messagesperc.tsx
@@ -140,7 +140,7 @@ const MessagesPerc: React.FC<MessagesPercProps> = ({
           </div>
         )}
         <button
-          id="Button1"
+          id="messages-perc-next-btn"
           className="bg-[#fabc05] w-[95%] md:w-1/3 h-12 cursor-pointer items-start rounded"
           onClick={handleNext}
           style={{ visibility: isbuttonVisible ? "visible" : "hidden" }}

--- a/src/layouts/index/peakhours/dawnpatrol.tsx
+++ b/src/layouts/index/peakhours/dawnpatrol.tsx
@@ -158,7 +158,7 @@ const DawnPatrol: React.FC<DawnPatrolProps> = ({
           </div>
         )}
         <button
-          id="Button1"
+          id="dawn-patrol-next-btn"
           className="bg-[#4286f5] md:w-1/3 h-12 cursor-pointer font-sans rounded w-full mt-2 md:mt-0"
           onClick={hanldeNext}
           style={{ visibility: isbuttonVisible ? "visible" : "hidden" }}

--- a/src/layouts/index/peakhours/nightwolf.tsx
+++ b/src/layouts/index/peakhours/nightwolf.tsx
@@ -31,7 +31,7 @@ export default function Nigtwold() {
           </div>
         </div>
         <button
-          id="Button1"
+          id="night-wolf-next-btn"
           className="bg-[#4286f5] flex flex-row justify-center pt-4 gap-3 w-2/5 h-12 cursor-pointer items-start rounded"
         >
           <div

--- a/src/layouts/index/peakhours/oyoyo.tsx
+++ b/src/layouts/index/peakhours/oyoyo.tsx
@@ -71,7 +71,7 @@ export default function OyoyExpress() {
           </div>
         </div>
         <button
-          id="Button1"
+          id="oyoyo-express-next-btn"
           className="bg-[#4286f5] flex flex-row justify-center pt-4 gap-3 w-1/3 h-12 cursor-pointer items-start rounded"
         >
           <div

--- a/src/layouts/index/peakhours/torinodeyfinish.tsx
+++ b/src/layouts/index/peakhours/torinodeyfinish.tsx
@@ -69,7 +69,7 @@ export default function ToriNoDeyFinish() {
           </div>
         </div>
         <button
-          id="Button1"
+          id="tori-no-dey-finish-next-btn"
           className="bg-[#4286f5] flex flex-row justify-center pt-4 gap-3 w-1/3 h-12 cursor-pointer items-start rounded"
         >
           <div

--- a/src/layouts/index/questionpercentile/questionpercentile.tsx
+++ b/src/layouts/index/questionpercentile/questionpercentile.tsx
@@ -123,7 +123,7 @@ const QuestionPercentile: React.FC<QuestionPercentileProps> = ({
         )}
 
         <button
-          id="Button1"
+          id="question-percentile-next-btn"
           className="bg-[#34a853] px-2 w-full md:w-1/3 h-12 cursor-pointer font-sans items-start rounded"
           onClick={() => handleNext()}
           style={{ visibility: isbuttonVisible ? "visible" : "hidden" }}

--- a/src/layouts/index/resourcecontributors/esteemedobserver.tsx
+++ b/src/layouts/index/resourcecontributors/esteemedobserver.tsx
@@ -122,7 +122,7 @@ const EsteemedObserver: React.FC<EsteemedObserverProps> = ({
           </div>
         )}
         <button
-          id="Button1"
+          id="ResourceContributorNextBtn"
           className="bg-[#fabc05] w-[95%] md:w-1/3 h-12 cursor-pointer items-start rounded"
           onClick={handleNext}
           style={{ visibility: isbuttonVisible ? "visible" : "hidden" }}

--- a/src/types/general.types.ts
+++ b/src/types/general.types.ts
@@ -9,7 +9,8 @@ interface MostActiveTime {
 }
 
 interface MostActiveMembers {
-  [key: string]: number;
+  name: string;
+  message_count: number;
 }
 
 interface MemberActivity {


### PR DESCRIPTION
This PR resolves the following issues:

Fixes #3: Fix incorrect MostActiveMembers type to match usage

Fixes #5: Avoid duplicate id="Button1" across multiple pages

I also noticed that Issue #11 appears to have already been resolved by a previous commit.